### PR TITLE
Add a trailing / to api/session requests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardConnection.java
@@ -110,7 +110,7 @@ public class ReviewboardConnection {
 
   private int ensureAuthentication(boolean withRetry) throws IOException {
     try {
-      GetMethod url = new GetMethod(reviewboardURL + "api/session");
+      GetMethod url = new GetMethod(reviewboardURL + "api/session/");
       url.setDoAuthentication(true);
       return http.executeMethod(url);
     } catch (IOException e) {


### PR DESCRIPTION
This ensures a proper 401 response is returned instead of a 30x (or 404).

This allows authentication to work on more reviewboard setups.

This is only tested on my setup, I don't know if this will break setups where the trailing / isn't needed.
