### PR TITLE
fix authentication.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardConnection.java
@@ -127,7 +127,7 @@ public class ReviewboardConnection {
 
   private int ensureAuthentication(boolean withRetry) throws IOException {
     try {
-      GetMethod url = new GetMethod(reviewboardURL + "api/"); //suspicion that session does not always exist
+      GetMethod url = new GetMethod(reviewboardURL + "api/session/");
       url.setDoAuthentication(true);
       return http.executeMethod(url);
     } catch (IOException e) {


### PR DESCRIPTION
reviewboard is a django project. all URLs need to be /-terminated unless the
site is configured otherwise (there is a config option to append slashes but
it is not necessarily set).

anyway, URI in the doc is /api/session/ so it must be right.
http://www.reviewboard.org/docs/manual/dev/webapi/2.0/resources/session/
