### PR TITLE
Use Project Full Name for Compatibility with the Folder Plugin.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardPollingBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardPollingBuilder.java
@@ -177,7 +177,7 @@ public class ReviewboardPollingBuilder extends Builder {
     public ListBoxModel doFillReviewbotJobNameItems() {
       ListBoxModel items = new ListBoxModel();
       for (AbstractProject project: Jenkins.getInstance().getAllItems(AbstractProject.class)) {
-        items.add(project.getName());
+        items.add(project.getFullName());
       }
       return items;
     }


### PR DESCRIPTION
The Folder Plugin allows for jobs to be nested in other special jobs of type folder. In order to allow selection of these jobs, it is important to expose the full job name, which includes the parent folder paths. I deployed this change in our environment and it is performing as desired.
