### PR TITLE
Revert "Use Project Full Name for Compatibility with the Folder Plugin."

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardPollingBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/jenkinsreviewbot/ReviewboardPollingBuilder.java
@@ -177,7 +177,7 @@ public class ReviewboardPollingBuilder extends Builder {
     public ListBoxModel doFillReviewbotJobNameItems() {
       ListBoxModel items = new ListBoxModel();
       for (AbstractProject project: Jenkins.getInstance().getAllItems(AbstractProject.class)) {
-        items.add(project.getFullName());
+        items.add(project.getName());
       }
       return items;
     }


### PR DESCRIPTION
Reverts vmware/jenkins-reviewbot#28. @ceagan Thanks for your contribution.  Please sign the CLA that you can find  in the repo.